### PR TITLE
Hotifx/cluster role

### DIFF
--- a/helm/chart/templates/controller/rbac.yml
+++ b/helm/chart/templates/controller/rbac.yml
@@ -14,8 +14,8 @@ rules:
   - apiGroups: [""]
     resources: ["services", "endpoints", "secrets"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["ingresses"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses", "ingressclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
     resources: ["ingresses/status"]
@@ -23,6 +23,7 @@ rules:
   - apiGroups: ["traefik.containo.us"]
     resources:
       - middlewares
+      - middlewaretcps
       - ingressroutes
       - traefikservices
       - ingressroutetcps

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -6,7 +6,7 @@ controller:
   ingressClassName: traefik
   image:
     repository: traefik
-    tag: "v2.5.6"
+    tag: "v2.6"
     pullPolicy: Always
   service:
     annotations: {}


### PR DESCRIPTION
**Description:**
🐛 with upgrade to k8s v1.18:
`Failed to list *v1beta1.IngressClass: ingressclasses.networking.k8s.io` error with Traefik v2.5

**Resolution:**
Update RBACs in cluster role
(https://stackoverflow.com/questions/63109422/getting-failed-to-list-v1beta1-ingressclass-ingressclasses-networking-k8s-io)