### PR TITLE
Update cluster role with networking.k8s.io resources

### DIFF
--- a/helm/chart/templates/controller/rbac.yml
+++ b/helm/chart/templates/controller/rbac.yml
@@ -17,19 +17,19 @@ rules:
   - apiGroups: ["extensions", "networking.k8s.io"]
     resources: ["ingresses", "ingressclasses"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
     resources: ["ingresses/status"]
     verbs: ["update"]
   - apiGroups: ["traefik.containo.us"]
     resources:
-      - middlewares
-      - middlewaretcps
       - ingressroutes
-      - traefikservices
       - ingressroutetcps
       - ingressrouteudps
+      - middlewares
+      - middlewaretcps
       - tlsoptions
       - tlsstores
+      - traefikservices
       - serverstransports
     verbs: ["get", "list", "watch"]
 ---

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,3 +1,5 @@
+# Inspired by
+# https://github.com/traefik/traefik-helm-chart/tree/master/traefik
 rbac:
   enabled: true
 


### PR DESCRIPTION
Error when deploying controller:

```
Error while updating ingress status: failed to update ingress status ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:kube-proxy:traefik-controller\" cannot update resource \"ingresses/status\" in API group \"networking.k8s.io\"
```