### PR TITLE
Deprecated kubernetes.io/ingress.class annotation

### DIFF
--- a/helm/chart/templates/controller/ingressclass.yml
+++ b/helm/chart/templates/controller/ingressclass.yml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: {{ .Values.controller.ingressClassName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  controller: traefik.io/ingress-controller

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,5 +1,10 @@
-# Inspired by
-# https://github.com/traefik/traefik-helm-chart/tree/master/traefik
+# v2.6 resources:
+#     - Traefik config
+#     https://doc.traefik.io/traefik/v2.6/
+#     - Helm chart
+#     https://github.com/traefik/traefik-helm-chart/tree/master/traefik
+#     - CRDs / ingresses
+#     https://github.com/traefik/traefik/tree/v2.6/pkg/provider/kubernetes/ingress/fixtures
 rbac:
   enabled: true
 


### PR DESCRIPTION
Official k8s doc on new IngressClass resource from v1.18+

https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/