### PR TITLE
NOOS-1698/upgrade-traefik-v3.6

### DIFF
--- a/helm/chart/crds/ingressroute.yaml
+++ b/helm/chart/crds/ingressroute.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressroutes.traefik.io
 spec:
   group: traefik.io
@@ -42,10 +42,30 @@ spec:
                 description: |-
                   EntryPoints defines the list of entry point names to bind to.
                   Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/entrypoints/
                   Default: all.
                 items:
                   type: string
+                type: array
+              parentRefs:
+                description: |-
+                  ParentRefs defines references to parent IngressRoute resources for multi-layer routing.
+                  When set, this IngressRoute's routers will be children of the referenced parent IngressRoute's routers.
+                  More info: https://doc.traefik.io/traefik/v3.6/routing/routers/#parentrefs
+                items:
+                  description: IngressRouteRef is a reference to an IngressRoute resource.
+                  properties:
+                    name:
+                      description: Name defines the name of the referenced IngressRoute
+                        resource.
+                      type: string
+                    namespace:
+                      description: Namespace defines the namespace of the referenced
+                        IngressRoute resource.
+                      type: string
+                  required:
+                  - name
+                  type: object
                 type: array
               routes:
                 description: Routes defines the list of routes.
@@ -63,12 +83,12 @@ spec:
                     match:
                       description: |-
                         Match defines the router's rule.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rule
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/
                       type: string
                     middlewares:
                       description: |-
                         Middlewares defines the list of references to Middleware resources.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-middleware
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/middleware/
                       items:
                         description: MiddlewareRef is a reference to a Middleware
                           resource.
@@ -88,7 +108,7 @@ spec:
                     observability:
                       description: |-
                         Observability defines the observability configuration for a router.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#observability
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/observability/
                       properties:
                         accessLogs:
                           description: AccessLogs enables access logs for this router.
@@ -111,7 +131,7 @@ spec:
                     priority:
                       description: |-
                         Priority defines the router's priority.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#priority
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/#priority
                       maximum: 9223372036854775000
                       type: integer
                     services:
@@ -226,6 +246,25 @@ spec:
                               PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                               By default, passHostHeader is true.
                             type: boolean
+                          passiveHealthCheck:
+                            description: PassiveHealthCheck defines passive health
+                              checks for ExternalName services.
+                            properties:
+                              failureWindow:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: FailureWindow defines the time window
+                                  during which the failed attempts must occur for
+                                  the server to be marked as unhealthy. It also defines
+                                  for how long the server will be considered unhealthy.
+                                x-kubernetes-int-or-string: true
+                              maxFailedAttempts:
+                                description: MaxFailedAttempts is the number of consecutive
+                                  failed attempts allowed within the failure window
+                                  before marking the server as unhealthy.
+                                type: integer
+                            type: object
                           port:
                             anyOf:
                             - type: integer
@@ -262,7 +301,7 @@ spec:
                           sticky:
                             description: |-
                               Sticky defines the sticky sessions configuration.
-                              More info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions
+                              More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
                             properties:
                               cookie:
                                 description: Cookie defines the sticky cookie configuration.
@@ -300,6 +339,9 @@ spec:
                                     - none
                                     - lax
                                     - strict
+                                    - None
+                                    - Lax
+                                    - Strict
                                     type: string
                                   secure:
                                     description: Secure defines whether the cookie
@@ -311,11 +353,13 @@ spec:
                           strategy:
                             description: |-
                               Strategy defines the load balancing strategy between the servers.
-                              Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
+                              Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
                               RoundRobin value is deprecated and supported for backward compatibility.
                             enum:
                             - wrr
                             - p2c
+                            - hrw
+                            - leasttime
                             - RoundRobin
                             type: string
                           weight:
@@ -331,7 +375,8 @@ spec:
                     syntax:
                       description: |-
                         Syntax defines the router's rule syntax.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rulesyntax
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax
+
                         Deprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.
                       type: string
                   required:
@@ -341,18 +386,18 @@ spec:
               tls:
                 description: |-
                   TLS defines the TLS configuration.
-                  More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#tls
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/router/#tls
                 properties:
                   certResolver:
                     description: |-
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
-                      More info: https://doc.traefik.io/traefik/v3.5/https/acme/#certificate-resolvers
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/tls/certificate-resolvers/acme/
                     type: string
                   domains:
                     description: |-
                       Domains defines the list of domains that will be used to issue certificates.
-                      More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#domains
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#domains
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
@@ -371,17 +416,17 @@ spec:
                     description: |-
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
-                      More info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-options/
                     properties:
                       name:
                         description: |-
                           Name defines the name of the referenced TLSOption.
-                          More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsoption
+                          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/tlsoption/
                         type: string
                       namespace:
                         description: |-
                           Namespace defines the namespace of the referenced TLSOption.
-                          More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsoption
+                          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/tlsoption/
                         type: string
                     required:
                     - name
@@ -398,12 +443,12 @@ spec:
                       name:
                         description: |-
                           Name defines the name of the referenced TLSStore.
-                          More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsstore
+                          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/tlsstore/
                         type: string
                       namespace:
                         description: |-
                           Namespace defines the namespace of the referenced TLSStore.
-                          More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsstore
+                          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/tlsstore/
                         type: string
                     required:
                     - name

--- a/helm/chart/crds/ingressroutetcp.yaml
+++ b/helm/chart/crds/ingressroutetcp.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressroutetcps.traefik.io
 spec:
   group: traefik.io
@@ -42,7 +42,7 @@ spec:
                 description: |-
                   EntryPoints defines the list of entry point names to bind to.
                   Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/entrypoints/
                   Default: all.
                 items:
                   type: string
@@ -55,7 +55,7 @@ spec:
                     match:
                       description: |-
                         Match defines the router's rule.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rule_1
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/
                       type: string
                     middlewares:
                       description: Middlewares defines the list of references to MiddlewareTCP
@@ -79,7 +79,7 @@ spec:
                     priority:
                       description: |-
                         Priority defines the router's priority.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#priority_1
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/#priority
                       maximum: 9223372036854775000
                       type: integer
                     services:
@@ -121,7 +121,9 @@ spec:
                           proxyProtocol:
                             description: |-
                               ProxyProtocol defines the PROXY protocol configuration.
-                              More info: https://doc.traefik.io/traefik/v3.5/routing/services/#proxy-protocol
+                              More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/service/#proxy-protocol
+
+                              Deprecated: ProxyProtocol will not be supported in future APIVersions, please use ServersTransport to configure ProxyProtocol instead.
                             properties:
                               version:
                                 description: Version defines the PROXY Protocol version
@@ -143,6 +145,7 @@ spec:
                               hence fully terminating the connection.
                               It is a duration in milliseconds, defaulting to 100.
                               A negative value means an infinite deadline (i.e. the reading capability is never closed).
+
                               Deprecated: TerminationDelay will not be supported in future APIVersions, please use ServersTransport to configure the TerminationDelay instead.
                             type: integer
                           tls:
@@ -162,7 +165,8 @@ spec:
                     syntax:
                       description: |-
                         Syntax defines the router's rule syntax.
-                        More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rulesyntax_1
+                        More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/#rulesyntax
+
                         Deprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.
                       enum:
                       - v3
@@ -175,18 +179,18 @@ spec:
               tls:
                 description: |-
                   TLS defines the TLS configuration on a layer 4 / TCP Route.
-                  More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#tls_1
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/router/#tls
                 properties:
                   certResolver:
                     description: |-
                       CertResolver defines the name of the certificate resolver to use.
                       Cert resolvers have to be configured in the static configuration.
-                      More info: https://doc.traefik.io/traefik/v3.5/https/acme/#certificate-resolvers
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/tls/certificate-resolvers/acme/
                     type: string
                   domains:
                     description: |-
                       Domains defines the list of domains that will be used to issue certificates.
-                      More info: https://doc.traefik.io/traefik/v3.5/routing/routers/#domains
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/tls/#domains
                     items:
                       description: Domain holds a domain name with SANs.
                       properties:
@@ -205,7 +209,7 @@ spec:
                     description: |-
                       Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.
                       If not defined, the `default` TLSOption is used.
-                      More info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/tls/#tls-options
                     properties:
                       name:
                         description: Name defines the name of the referenced Traefik

--- a/helm/chart/crds/ingressrouteudp.yaml
+++ b/helm/chart/crds/ingressrouteudp.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: ingressrouteudps.traefik.io
 spec:
   group: traefik.io
@@ -42,7 +42,7 @@ spec:
                 description: |-
                   EntryPoints defines the list of entry point names to bind to.
                   Entry points have to be configured in the static configuration.
-                  More info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/entrypoints/
                   Default: all.
                 items:
                   type: string

--- a/helm/chart/crds/middlewares.yaml
+++ b/helm/chart/crds/middlewares.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: middlewares.traefik.io
 spec:
   group: traefik.io
@@ -18,7 +18,7 @@ spec:
       openAPIV3Schema:
         description: |-
           Middleware is the CRD implementation of a Traefik Middleware.
-          More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/overview/
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/overview/
         properties:
           apiVersion:
             description: |-
@@ -44,7 +44,7 @@ spec:
                 description: |-
                   AddPrefix holds the add prefix middleware configuration.
                   This middleware updates the path of a request before forwarding it.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/addprefix/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/addprefix/
                 properties:
                   prefix:
                     description: |-
@@ -59,12 +59,12 @@ spec:
                 description: |-
                   BasicAuth holds the basic auth middleware configuration.
                   This middleware restricts access to your services to known users.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/basicauth/
                 properties:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/basicauth/#headerfield
                     type: string
                   realm:
                     description: |-
@@ -85,7 +85,7 @@ spec:
                 description: |-
                   Buffering holds the buffering middleware configuration.
                   This middleware retries or limits the size of requests that can be forwarded to backends.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/buffering/#maxrequestbodybytes
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/buffering/#maxrequestbodybytes
                 properties:
                   maxRequestBodyBytes:
                     description: |-
@@ -117,14 +117,14 @@ spec:
                     description: |-
                       RetryExpression defines the retry conditions.
                       It is a logical combination of functions with operators AND (&&) and OR (||).
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/buffering/#retryexpression
+                      More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/buffering/#retryexpression
                     type: string
                 type: object
               chain:
                 description: |-
                   Chain holds the configuration of the chain middleware.
                   This middleware enables to define reusable combinations of other pieces of middleware.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/chain/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/chain/
                 properties:
                   middlewares:
                     description: Middlewares is the list of MiddlewareRef which composes
@@ -187,7 +187,7 @@ spec:
                 description: |-
                   Compress holds the compress middleware configuration.
                   This middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/compress/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/compress/
                 properties:
                   defaultEncoding:
                     description: DefaultEncoding specifies the default encoding if
@@ -230,6 +230,7 @@ spec:
                     description: |-
                       AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,
                       be automatically set to a value derived from the contents of the response.
+
                       Deprecated: AutoDetect option is deprecated, Content-Type middleware is only meant to be used to enable the content-type detection, please remove any usage of this option.
                     type: boolean
                 type: object
@@ -237,12 +238,12 @@ spec:
                 description: |-
                   DigestAuth holds the digest auth middleware configuration.
                   This middleware restricts access to your services to known users.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/digestauth/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/digestauth/
                 properties:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/digestauth/#headerfield
                     type: string
                   realm:
                     description: |-
@@ -262,8 +263,16 @@ spec:
                 description: |-
                   ErrorPage holds the custom error middleware configuration.
                   This middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/errorpages/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/errorpages/
                 properties:
+                  errorRequestHeaders:
+                    description: |-
+                      ErrorRequestHeaders defines the list of request headers forwarded to the error page service.
+                      When nil (not set), all original request headers are forwarded.
+                      Set to an empty list to forward no headers, or list specific headers to forward only those.
+                    items:
+                      type: string
+                    type: array
                   query:
                     description: |-
                       Query defines the URL for the error page (hosted by service).
@@ -274,7 +283,7 @@ spec:
                   service:
                     description: |-
                       Service defines the reference to a Kubernetes Service that will serve the error page.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/errorpages/#service
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/errorpages/#service
                     properties:
                       healthCheck:
                         description: Healthcheck defines health checks for ExternalName
@@ -380,6 +389,25 @@ spec:
                           PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                           By default, passHostHeader is true.
                         type: boolean
+                      passiveHealthCheck:
+                        description: PassiveHealthCheck defines passive health checks
+                          for ExternalName services.
+                        properties:
+                          failureWindow:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: FailureWindow defines the time window during
+                              which the failed attempts must occur for the server
+                              to be marked as unhealthy. It also defines for how long
+                              the server will be considered unhealthy.
+                            x-kubernetes-int-or-string: true
+                          maxFailedAttempts:
+                            description: MaxFailedAttempts is the number of consecutive
+                              failed attempts allowed within the failure window before
+                              marking the server as unhealthy.
+                            type: integer
+                        type: object
                       port:
                         anyOf:
                         - type: integer
@@ -416,7 +444,7 @@ spec:
                       sticky:
                         description: |-
                           Sticky defines the sticky sessions configuration.
-                          More info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions
+                          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
                         properties:
                           cookie:
                             description: Cookie defines the sticky cookie configuration.
@@ -453,6 +481,9 @@ spec:
                                 - none
                                 - lax
                                 - strict
+                                - None
+                                - Lax
+                                - Strict
                                 type: string
                               secure:
                                 description: Secure defines whether the cookie can
@@ -464,11 +495,13 @@ spec:
                       strategy:
                         description: |-
                           Strategy defines the load balancing strategy between the servers.
-                          Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
+                          Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
                           RoundRobin value is deprecated and supported for backward compatibility.
                         enum:
                         - wrr
                         - p2c
+                        - hrw
+                        - leasttime
                         - RoundRobin
                         type: string
                       weight:
@@ -503,7 +536,7 @@ spec:
                 description: |-
                   ForwardAuth holds the forward auth middleware configuration.
                   This middleware delegates the request authentication to a Service.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/forwardauth/
                 properties:
                   addAuthCookiesToResponse:
                     description: AddAuthCookiesToResponse defines the list of cookies
@@ -531,7 +564,7 @@ spec:
                   authResponseHeadersRegex:
                     description: |-
                       AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/#authresponseheadersregex
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/forwardauth/#authresponseheadersregex
                     type: string
                   forwardBody:
                     description: ForwardBody defines whether to send the request body
@@ -540,11 +573,16 @@ spec:
                   headerField:
                     description: |-
                       HeaderField defines a header field to store the authenticated user.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/#headerfield
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/forwardauth/#headerfield
                     type: string
                   maxBodySize:
                     description: MaxBodySize defines the maximum body size in bytes
                       allowed to be forwarded to the authentication server.
+                    format: int64
+                    type: integer
+                  maxResponseBodySize:
+                    description: MaxResponseBodySize defines the maximum body size
+                      in bytes allowed in the response from the authentication server.
                     format: int64
                     type: integer
                   preserveLocationHeader:
@@ -581,8 +619,10 @@ spec:
                         type: boolean
                     type: object
                   trustForwardHeader:
-                    description: 'TrustForwardHeader defines whether to trust (ie:
-                      forward) all X-Forwarded-* headers.'
+                    description: |-
+                      TrustForwardHeader defines whether to trust (ie: forward) all X-Forwarded-* headers.
+
+                      Deprecated: Use forwardedHeaders.trustedIPs at the EntryPoint level instead, and set trustForwardHeader to true on this middleware.
                     type: boolean
                 type: object
               grpcWeb:
@@ -602,7 +642,7 @@ spec:
                 description: |-
                   Headers holds the headers middleware configuration.
                   This middleware manages the requests and responses headers.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/headers/#customrequestheaders
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/headers/#customrequestheaders
                 properties:
                   accessControlAllowCredentials:
                     description: AccessControlAllowCredentials defines whether the
@@ -774,7 +814,7 @@ spec:
                 description: |-
                   InFlightReq holds the in-flight request middleware configuration.
                   This middleware limits the number of requests being processed and served concurrently.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/inflightreq/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/inflightreq/
                 properties:
                   amount:
                     description: |-
@@ -788,12 +828,12 @@ spec:
                       SourceCriterion defines what criterion is used to group requests as originating from a common source.
                       If several strategies are defined at the same time, an error will be raised.
                       If none are set, the default is to use the requestHost.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/inflightreq/#sourcecriterion
+                      More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/inflightreq/#sourcecriterion
                     properties:
                       ipStrategy:
                         description: |-
                           IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.
-                          More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy
+                          More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/ipallowlist/#ipstrategy
                         properties:
                           depth:
                             description: Depth tells Traefik to use the X-Forwarded-For
@@ -829,12 +869,12 @@ spec:
                 description: |-
                   IPAllowList holds the IP allowlist middleware configuration.
                   This middleware limits allowed requests based on the client IP.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/ipallowlist/
                 properties:
                   ipStrategy:
                     description: |-
                       IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy
+                      More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/ipallowlist/#ipstrategy
                     properties:
                       depth:
                         description: Depth tells Traefik to use the X-Forwarded-For
@@ -872,7 +912,7 @@ spec:
                   ipStrategy:
                     description: |-
                       IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.
-                      More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy
+                      More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/ipallowlist/#ipstrategy
                     properties:
                       depth:
                         description: Depth tells Traefik to use the X-Forwarded-For
@@ -903,7 +943,7 @@ spec:
                 description: |-
                   PassTLSClientCert holds the pass TLS client cert middleware configuration.
                   This middleware adds the selected data from the passed client TLS certificate to a header.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/passtlsclientcert/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/passtlsclientcert/
                 properties:
                   info:
                     description: Info selects the specific client certificate details
@@ -1006,13 +1046,13 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 description: |-
                   Plugin defines the middleware plugin configuration.
-                  More info: https://doc.traefik.io/traefik/plugins/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/overview/#community-middlewares
                 type: object
               rateLimit:
                 description: |-
                   RateLimit holds the rate limit configuration.
                   This middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ratelimit/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/ratelimit/
                 properties:
                   average:
                     description: |-
@@ -1131,7 +1171,7 @@ spec:
                       ipStrategy:
                         description: |-
                           IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.
-                          More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy
+                          More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/ipallowlist/#ipstrategy
                         properties:
                           depth:
                             description: Depth tells Traefik to use the X-Forwarded-For
@@ -1167,7 +1207,7 @@ spec:
                 description: |-
                   RedirectRegex holds the redirect regex middleware configuration.
                   This middleware redirects a request using regex matching and replacement.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/redirectregex/#regex
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/redirectregex/#regex
                 properties:
                   permanent:
                     description: Permanent defines whether the redirection is permanent
@@ -1186,11 +1226,12 @@ spec:
                 description: |-
                   RedirectScheme holds the redirect scheme middleware configuration.
                   This middleware redirects requests from a scheme/port to another.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/redirectscheme/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/redirectscheme/
                 properties:
                   permanent:
-                    description: Permanent defines whether the redirection is permanent
-                      (308).
+                    description: |-
+                      Permanent defines whether the redirection is permanent.
+                      For HTTP GET requests a 301 is returned, otherwise a 308 is returned.
                     type: boolean
                   port:
                     description: Port defines the port of the new URL.
@@ -1203,7 +1244,7 @@ spec:
                 description: |-
                   ReplacePath holds the replace path middleware configuration.
                   This middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/replacepath/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/replacepath/
                 properties:
                   path:
                     description: Path defines the path to use as replacement in the
@@ -1214,7 +1255,7 @@ spec:
                 description: |-
                   ReplacePathRegex holds the replace path regex middleware configuration.
                   This middleware replaces the path of a URL using regex matching and replacement.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/replacepathregex/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/replacepathregex/
                 properties:
                   regex:
                     description: Regex defines the regular expression used to match
@@ -1230,7 +1271,7 @@ spec:
                   Retry holds the retry middleware configuration.
                   This middleware reissues requests a given number of times to a backend server if that server does not reply.
                   As soon as the server answers, the middleware stops retrying, regardless of the response status.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/retry/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/middlewares/retry/
                 properties:
                   attempts:
                     description: Attempts defines how many times the request should
@@ -1254,7 +1295,7 @@ spec:
                 description: |-
                   StripPrefix holds the strip prefix middleware configuration.
                   This middleware removes the specified prefixes from the URL path.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/stripprefix/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/stripprefix/
                 properties:
                   forceSlash:
                     description: |-
@@ -1273,7 +1314,7 @@ spec:
                 description: |-
                   StripPrefixRegex holds the strip prefix regex middleware configuration.
                   This middleware removes the matching prefixes from the URL path.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/http/stripprefixregex/
+                  More info: https://doc.traefik.io/traefik/v3.6/middlewares/http/stripprefixregex/
                 properties:
                   regex:
                     description: Regex defines the regular expression to match the

--- a/helm/chart/crds/middlewarestcp.yaml
+++ b/helm/chart/crds/middlewarestcp.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: middlewaretcps.traefik.io
 spec:
   group: traefik.io
@@ -18,7 +18,7 @@ spec:
       openAPIV3Schema:
         description: |-
           MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.
-          More info: https://doc.traefik.io/traefik/v3.5/middlewares/overview/
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/overview/
         properties:
           apiVersion:
             description: |-
@@ -55,7 +55,7 @@ spec:
                 description: |-
                   IPAllowList defines the IPAllowList middleware configuration.
                   This middleware accepts/refuses connections based on the client IP.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/tcp/ipallowlist/
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/ipallowlist/
                 properties:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of
@@ -68,8 +68,9 @@ spec:
                 description: |-
                   IPWhiteList defines the IPWhiteList middleware configuration.
                   This middleware accepts/refuses connections based on the client IP.
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/ipwhitelist/
+
                   Deprecated: please use IPAllowList instead.
-                  More info: https://doc.traefik.io/traefik/v3.5/middlewares/tcp/ipwhitelist/
                 properties:
                   sourceRange:
                     description: SourceRange defines the allowed IPs (or ranges of

--- a/helm/chart/crds/serverstransports.yaml
+++ b/helm/chart/crds/serverstransports.yaml
@@ -1,9 +1,8 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverstransports.traefik.io
 spec:
   group: traefik.io
@@ -21,7 +20,7 @@ spec:
           ServersTransport is the CRD implementation of a ServersTransport.
           If no serversTransport is specified, the default@internal will be used.
           The default@internal serversTransport is created from the static configuration.
-          More info: https://doc.traefik.io/traefik/v3.5/routing/services/#serverstransport_1
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/serverstransport/
         properties:
           apiVersion:
             description: |-
@@ -107,7 +106,7 @@ spec:
               maxIdleConnsPerHost:
                 description: MaxIdleConnsPerHost controls the maximum idle (keep-alive)
                   to keep per-host.
-                minimum: 0
+                minimum: -1
                 type: integer
               peerCertURI:
                 description: PeerCertURI defines the peer cert URI used to match against
@@ -139,6 +138,7 @@ spec:
               rootCAsSecrets:
                 description: |-
                   RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.
+
                   Deprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.
                 items:
                   type: string

--- a/helm/chart/crds/serverstransporttcps.yaml
+++ b/helm/chart/crds/serverstransporttcps.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: serverstransporttcps.traefik.io
 spec:
   group: traefik.io
@@ -20,7 +20,7 @@ spec:
           ServersTransportTCP is the CRD implementation of a TCPServersTransport.
           If no tcpServersTransport is specified, a default one named default@internal will be used.
           The default@internal tcpServersTransport can be configured in the static configuration.
-          More info: https://doc.traefik.io/traefik/v3.5/routing/services/#serverstransport_3
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/serverstransport/
         properties:
           apiVersion:
             description: |-
@@ -62,6 +62,15 @@ spec:
                   to a backend server can be established.
                 pattern: ^([0-9]+(ns|us|µs|ms|s|m|h)?)+$
                 x-kubernetes-int-or-string: true
+              proxyProtocol:
+                description: ProxyProtocol holds the PROXY Protocol configuration.
+                properties:
+                  version:
+                    description: Version defines the PROXY Protocol version to use.
+                    maximum: 2
+                    minimum: 1
+                    type: integer
+                type: object
               terminationDelay:
                 anyOf:
                 - type: integer
@@ -114,6 +123,7 @@ spec:
                   rootCAsSecrets:
                     description: |-
                       RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.
+
                       Deprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.
                     items:
                       type: string

--- a/helm/chart/crds/tlsoptions.yaml
+++ b/helm/chart/crds/tlsoptions.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tlsoptions.traefik.io
 spec:
   group: traefik.io
@@ -18,7 +18,7 @@ spec:
       openAPIV3Schema:
         description: |-
           TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.
-          More info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#tls-options
         properties:
           apiVersion:
             description: |-
@@ -43,14 +43,14 @@ spec:
               alpnProtocols:
                 description: |-
                   ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.
-                  More info: https://doc.traefik.io/traefik/v3.5/https/tls/#alpn-protocols
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#alpn-protocols
                 items:
                   type: string
                 type: array
               cipherSuites:
                 description: |-
                   CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.
-                  More info: https://doc.traefik.io/traefik/v3.5/https/tls/#cipher-suites
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#cipher-suites
                 items:
                   type: string
                 type: array
@@ -78,7 +78,7 @@ spec:
               curvePreferences:
                 description: |-
                   CurvePreferences defines the preferred elliptic curves.
-                  More info: https://doc.traefik.io/traefik/v3.5/https/tls/#curve-preferences
+                  More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#curve-preferences
                 items:
                   type: string
                 type: array
@@ -102,6 +102,7 @@ spec:
                 description: |-
                   PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.
                   It is enabled automatically when minVersion or maxVersion is set.
+
                   Deprecated: https://github.com/golang/go/issues/45430
                 type: boolean
               sniStrict:

--- a/helm/chart/crds/tlsstores.yaml
+++ b/helm/chart/crds/tlsstores.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: tlsstores.traefik.io
 spec:
   group: traefik.io
@@ -20,7 +20,7 @@ spec:
           TLSStore is the CRD implementation of a Traefik TLS Store.
           For the time being, only the TLSStore named default is supported.
           This means that you cannot have two stores that are named default in different Kubernetes namespaces.
-          More info: https://doc.traefik.io/traefik/v3.5/https/tls/#certificates-stores
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/tls/tls-certificates/#certificates-stores#certificates-stores
         properties:
           apiVersion:
             description: |-

--- a/helm/chart/crds/traefikservices.yaml
+++ b/helm/chart/crds/traefikservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: traefikservices.traefik.io
 spec:
   group: traefik.io
@@ -21,7 +21,7 @@ spec:
           TraefikService object allows to:
           - Apply weight to Services on load-balancing
           - Mirror traffic on services
-          More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-traefikservice
+          More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/traefikservice/
         properties:
           apiVersion:
             description: |-
@@ -43,6 +43,247 @@ spec:
           spec:
             description: TraefikServiceSpec defines the desired state of a TraefikService.
             properties:
+              highestRandomWeight:
+                description: HighestRandomWeight defines the highest random weight
+                  service configuration.
+                properties:
+                  services:
+                    description: Services defines the list of Kubernetes Service and/or
+                      TraefikService to load-balance, with weight.
+                    items:
+                      description: Service defines an upstream HTTP service to proxy
+                        traffic to.
+                      properties:
+                        healthCheck:
+                          description: Healthcheck defines health checks for ExternalName
+                            services.
+                          properties:
+                            followRedirects:
+                              description: |-
+                                FollowRedirects defines whether redirects should be followed during the health check calls.
+                                Default: true
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              description: Headers defines custom headers to be sent
+                                to the health check endpoint.
+                              type: object
+                            hostname:
+                              description: Hostname defines the value of hostname
+                                in the Host header of the health check request.
+                              type: string
+                            interval:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Interval defines the frequency of the health check calls for healthy targets.
+                                Default: 30s
+                              x-kubernetes-int-or-string: true
+                            method:
+                              description: Method defines the healthcheck method.
+                              type: string
+                            mode:
+                              description: |-
+                                Mode defines the health check mode.
+                                If defined to grpc, will use the gRPC health check protocol to probe the server.
+                                Default: http
+                              type: string
+                            path:
+                              description: Path defines the server URL path for the
+                                health check endpoint.
+                              type: string
+                            port:
+                              description: Port defines the server URL port for the
+                                health check endpoint.
+                              type: integer
+                            scheme:
+                              description: Scheme replaces the server URL scheme for
+                                the health check endpoint.
+                              type: string
+                            status:
+                              description: Status defines the expected HTTP status
+                                code of the response to the health check request.
+                              type: integer
+                            timeout:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.
+                                Default: 5s
+                              x-kubernetes-int-or-string: true
+                            unhealthyInterval:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.
+                                When UnhealthyInterval is not defined, it defaults to the Interval value.
+                                Default: 30s
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        kind:
+                          description: Kind defines the kind of the Service.
+                          enum:
+                          - Service
+                          - TraefikService
+                          type: string
+                        name:
+                          description: |-
+                            Name defines the name of the referenced Kubernetes Service or TraefikService.
+                            The differentiation between the two is specified in the Kind field.
+                          type: string
+                        namespace:
+                          description: Namespace defines the namespace of the referenced
+                            Kubernetes Service or TraefikService.
+                          type: string
+                        nativeLB:
+                          description: |-
+                            NativeLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the pods IPs or if the only child is the Kubernetes Service clusterIP.
+                            The Kubernetes Service itself does load-balance to the pods.
+                            By default, NativeLB is false.
+                          type: boolean
+                        nodePortLB:
+                          description: |-
+                            NodePortLB controls, when creating the load-balancer,
+                            whether the LB's children are directly the nodes internal IPs using the nodePort when the service type is NodePort.
+                            It allows services to be reachable when Traefik runs externally from the Kubernetes cluster but within the same network of the nodes.
+                            By default, NodePortLB is false.
+                          type: boolean
+                        passHostHeader:
+                          description: |-
+                            PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
+                            By default, passHostHeader is true.
+                          type: boolean
+                        passiveHealthCheck:
+                          description: PassiveHealthCheck defines passive health checks
+                            for ExternalName services.
+                          properties:
+                            failureWindow:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: FailureWindow defines the time window during
+                                which the failed attempts must occur for the server
+                                to be marked as unhealthy. It also defines for how
+                                long the server will be considered unhealthy.
+                              x-kubernetes-int-or-string: true
+                            maxFailedAttempts:
+                              description: MaxFailedAttempts is the number of consecutive
+                                failed attempts allowed within the failure window
+                                before marking the server as unhealthy.
+                              type: integer
+                          type: object
+                        port:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Port defines the port of a Kubernetes Service.
+                            This can be a reference to a named port.
+                          x-kubernetes-int-or-string: true
+                        responseForwarding:
+                          description: ResponseForwarding defines how Traefik forwards
+                            the response from the upstream Kubernetes Service to the
+                            client.
+                          properties:
+                            flushInterval:
+                              description: |-
+                                FlushInterval defines the interval, in milliseconds, in between flushes to the client while copying the response body.
+                                A negative value means to flush immediately after each write to the client.
+                                This configuration is ignored when ReverseProxy recognizes a response as a streaming response;
+                                for such responses, writes are flushed to the client immediately.
+                                Default: 100ms
+                              type: string
+                          type: object
+                        scheme:
+                          description: |-
+                            Scheme defines the scheme to use for the request to the upstream Kubernetes Service.
+                            It defaults to https when Kubernetes Service port is 443, http otherwise.
+                          type: string
+                        serversTransport:
+                          description: |-
+                            ServersTransport defines the name of ServersTransport resource to use.
+                            It allows to configure the transport between Traefik and your servers.
+                            Can only be used on a Kubernetes Service.
+                          type: string
+                        sticky:
+                          description: |-
+                            Sticky defines the sticky sessions configuration.
+                            More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
+                          properties:
+                            cookie:
+                              description: Cookie defines the sticky cookie configuration.
+                              properties:
+                                domain:
+                                  description: |-
+                                    Domain defines the host to which the cookie will be sent.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+                                  type: string
+                                httpOnly:
+                                  description: HTTPOnly defines whether the cookie
+                                    can be accessed by client-side APIs, such as JavaScript.
+                                  type: boolean
+                                maxAge:
+                                  description: |-
+                                    MaxAge defines the number of seconds until the cookie expires.
+                                    When set to a negative number, the cookie expires immediately.
+                                    When set to zero, the cookie never expires.
+                                  type: integer
+                                name:
+                                  description: Name defines the Cookie name.
+                                  type: string
+                                path:
+                                  description: |-
+                                    Path defines the path that must exist in the requested URL for the browser to send the Cookie header.
+                                    When not provided the cookie will be sent on every request to the domain.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#pathpath-value
+                                  type: string
+                                sameSite:
+                                  description: |-
+                                    SameSite defines the same site policy.
+                                    More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+                                  enum:
+                                  - none
+                                  - lax
+                                  - strict
+                                  - None
+                                  - Lax
+                                  - Strict
+                                  type: string
+                                secure:
+                                  description: Secure defines whether the cookie can
+                                    only be transmitted over an encrypted connection
+                                    (i.e. HTTPS).
+                                  type: boolean
+                              type: object
+                          type: object
+                        strategy:
+                          description: |-
+                            Strategy defines the load balancing strategy between the servers.
+                            Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
+                            RoundRobin value is deprecated and supported for backward compatibility.
+                          enum:
+                          - wrr
+                          - p2c
+                          - hrw
+                          - leasttime
+                          - RoundRobin
+                          type: string
+                        weight:
+                          description: |-
+                            Weight defines the weight and should only be specified when Name references a TraefikService object
+                            (and to be precise, one that embeds a Weighted Round Robin).
+                          minimum: 0
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
               mirroring:
                 description: Mirroring defines the Mirroring service configuration.
                 properties:
@@ -244,6 +485,25 @@ spec:
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
                           type: boolean
+                        passiveHealthCheck:
+                          description: PassiveHealthCheck defines passive health checks
+                            for ExternalName services.
+                          properties:
+                            failureWindow:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: FailureWindow defines the time window during
+                                which the failed attempts must occur for the server
+                                to be marked as unhealthy. It also defines for how
+                                long the server will be considered unhealthy.
+                              x-kubernetes-int-or-string: true
+                            maxFailedAttempts:
+                              description: MaxFailedAttempts is the number of consecutive
+                                failed attempts allowed within the failure window
+                                before marking the server as unhealthy.
+                              type: integer
+                          type: object
                         percent:
                           description: |-
                             Percent defines the part of the traffic to mirror.
@@ -285,7 +545,7 @@ spec:
                         sticky:
                           description: |-
                             Sticky defines the sticky sessions configuration.
-                            More info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions
+                            More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
                           properties:
                             cookie:
                               description: Cookie defines the sticky cookie configuration.
@@ -322,6 +582,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -333,11 +596,13 @@ spec:
                         strategy:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
+                            Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
                             RoundRobin value is deprecated and supported for backward compatibility.
                           enum:
                           - wrr
                           - p2c
+                          - hrw
+                          - leasttime
                           - RoundRobin
                           type: string
                         weight:
@@ -378,6 +643,25 @@ spec:
                       PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                       By default, passHostHeader is true.
                     type: boolean
+                  passiveHealthCheck:
+                    description: PassiveHealthCheck defines passive health checks
+                      for ExternalName services.
+                    properties:
+                      failureWindow:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: FailureWindow defines the time window during
+                          which the failed attempts must occur for the server to be
+                          marked as unhealthy. It also defines for how long the server
+                          will be considered unhealthy.
+                        x-kubernetes-int-or-string: true
+                      maxFailedAttempts:
+                        description: MaxFailedAttempts is the number of consecutive
+                          failed attempts allowed within the failure window before
+                          marking the server as unhealthy.
+                        type: integer
+                    type: object
                   port:
                     anyOf:
                     - type: integer
@@ -413,7 +697,7 @@ spec:
                   sticky:
                     description: |-
                       Sticky defines the sticky sessions configuration.
-                      More info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
                     properties:
                       cookie:
                         description: Cookie defines the sticky cookie configuration.
@@ -450,6 +734,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only
@@ -460,11 +747,13 @@ spec:
                   strategy:
                     description: |-
                       Strategy defines the load balancing strategy between the servers.
-                      Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
+                      Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
                       RoundRobin value is deprecated and supported for backward compatibility.
                     enum:
                     - wrr
                     - p2c
+                    - hrw
+                    - leasttime
                     - RoundRobin
                     type: string
                   weight:
@@ -590,6 +879,25 @@ spec:
                             PassHostHeader defines whether the client Host header is forwarded to the upstream Kubernetes Service.
                             By default, passHostHeader is true.
                           type: boolean
+                        passiveHealthCheck:
+                          description: PassiveHealthCheck defines passive health checks
+                            for ExternalName services.
+                          properties:
+                            failureWindow:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: FailureWindow defines the time window during
+                                which the failed attempts must occur for the server
+                                to be marked as unhealthy. It also defines for how
+                                long the server will be considered unhealthy.
+                              x-kubernetes-int-or-string: true
+                            maxFailedAttempts:
+                              description: MaxFailedAttempts is the number of consecutive
+                                failed attempts allowed within the failure window
+                                before marking the server as unhealthy.
+                              type: integer
+                          type: object
                         port:
                           anyOf:
                           - type: integer
@@ -626,7 +934,7 @@ spec:
                         sticky:
                           description: |-
                             Sticky defines the sticky sessions configuration.
-                            More info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions
+                            More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/load-balancing/service/#sticky-sessions
                           properties:
                             cookie:
                               description: Cookie defines the sticky cookie configuration.
@@ -663,6 +971,9 @@ spec:
                                   - none
                                   - lax
                                   - strict
+                                  - None
+                                  - Lax
+                                  - Strict
                                   type: string
                                 secure:
                                   description: Secure defines whether the cookie can
@@ -674,11 +985,13 @@ spec:
                         strategy:
                           description: |-
                             Strategy defines the load balancing strategy between the servers.
-                            Supported values are: wrr (Weighed round-robin) and p2c (Power of two choices).
+                            Supported values are: wrr (Weighed round-robin), p2c (Power of two choices), hrw (Highest Random Weight), and leasttime (Least-Time).
                             RoundRobin value is deprecated and supported for backward compatibility.
                           enum:
                           - wrr
                           - p2c
+                          - hrw
+                          - leasttime
                           - RoundRobin
                           type: string
                         weight:
@@ -694,7 +1007,7 @@ spec:
                   sticky:
                     description: |-
                       Sticky defines whether sticky sessions are enabled.
-                      More info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#stickiness-and-load-balancing
+                      More info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/kubernetes/crd/http/traefikservice/#stickiness-and-load-balancing
                     properties:
                       cookie:
                         description: Cookie defines the sticky cookie configuration.
@@ -731,6 +1044,9 @@ spec:
                             - none
                             - lax
                             - strict
+                            - None
+                            - Lax
+                            - Strict
                             type: string
                           secure:
                             description: Secure defines whether the cookie can only

--- a/helm/chart/templates/controller/deployment.yml
+++ b/helm/chart/templates/controller/deployment.yml
@@ -18,7 +18,7 @@ spec:
       labels:
         app: traefik-lb
       annotations:
-        strategyTrigger: {{ randAlphaNum 5 | quote }}
+        deployTag: {{ .Values.controller.deployTag }}
     spec:
       {{- if .Values.controller.priorityClassName }}
       priorityClassName: {{ .Values.controller.priorityClassName }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,10 +1,10 @@
-# v3.5 resources:
+# v3.6 resources:
 #     - Traefik config
-#     https://doc.traefik.io/traefik/v3.5/
+#     https://doc.traefik.io/traefik/v3.6/
 #     - Helm chart
 #     https://github.com/traefik/traefik-helm-chart/tree/master/traefik
 #     - CRDs / ingresses
-#     https://github.com/traefik/traefik/tree/v3.5/pkg/provider/kubernetes/ingress/fixtures
+#     https://github.com/traefik/traefik/tree/v3.6/pkg/provider/kubernetes/ingress/fixtures
 rbac:
   enabled: false
 
@@ -13,12 +13,12 @@ controller:
   enforceTLS: false
   # Set Traefik as the cluster default reverse proxy
   ingressClassName: traefik
-  isDefaultIngressClass: false
+  isDefaultIngressClass: true
   # Overall deployment
   priorityClassName:
   image:
     repository: traefik
-    tag: "v3.5.0"
+    tag: "v3.6.25"
     pullPolicy: Always
   service:
     annotations: {}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -9,6 +9,7 @@ rbac:
   enabled: false
 
 controller:
+  deployTag: latest
   # Whether to enforce TLS by redirecting HTTP to HTTPS
   enforceTLS: false
   # Set Traefik as the cluster default reverse proxy

--- a/local/helm-values.yaml
+++ b/local/helm-values.yaml
@@ -3,14 +3,8 @@ rbac:
   enabled: true
 
 controller:
+  # Https to Http permanent redirect not required for local clusters
   enforceTLS: false
-  priorityClassName: system-cluster-critical
-  ingressClassName: traefik
-  isDefaultIngressClass: true
-  image:
-    repository: traefik
-    tag: "v3.5.0"
-    pullPolicy: Always
   resources:
     requests:
       cpu: 1m


### PR DESCRIPTION
# Description

<!--- Add JIRA reference here -->
**JIRA Reference**: [NOOS-1698](https://noosenergy.atlassian.net/browse/NOOS-1698)

### Summary

Upgrades the bundled Traefik controller image and its manually-vendored CRDs from `v3.5.0` to the latest `v3.6` patch (`v3.6.25`). No RBAC, static config, or dynamic config changes are required for this hop — hardening improvements identified during the review (`crossProviderNamespaces`, `underscoreHeadersStrategy`, `encodedCharacters`) could be tracked separately as a follow-up PR.

### Commits

1. **`Switch traefik app by default in Helm chart to v3.6`**
   values.yaml — bump `controller.image.tag` to `v3.6.25` and update inline doc-reference comments to `v3.6`.
2. **`Upgrade Traefiks CRDs to reference Traefik v3.6`**
   helm/chart/crds/*.yaml (10 files) — regenerated from the official upstream manifest, re-split per kind into the existing file layout.

### Official references

- Migration guide: [doc.traefik.io/traefik/v3.6/migrate/v3](https://doc.traefik.io/traefik/v3.6/migrate/v3/)
- v3.6.25 release notes: [github.com/traefik/traefik/releases/tag/v3.6.25](https://github.com/traefik/traefik/releases/tag/v3.6.25)
- CRD manifest source: [raw.githubusercontent.com/traefik/traefik/v3.6/.../kubernetes-crd-definition-v1.yml](https://raw.githubusercontent.com/traefik/traefik/v3.6/docs/content/reference/dynamic-configuration/kubernetes-crd-definition-v1.yml)
- Community Helm chart (for cross-reference only, not consumed directly): [github.com/traefik/traefik-helm-chart](https://github.com/traefik/traefik-helm-chart/tree/master/traefik)

### Notable CRD schema additions picked up (per migration guide)

| Change | Introduced | Reference |
|---|---|---|
| `leasttime` load-balancer strategy | v3.6.0 | [v3.6.0 notes](https://doc.traefik.io/traefik/v3.6/migrate/v3/#v360) |
| `maxResponseBodySize` on ForwardAuth middleware | v3.6.9 | [v3.6.9 notes](https://doc.traefik.io/traefik/v3.6/migrate/v3/#v369) |
| `errorRequestHeaders` on Errors middleware | v3.6.15 (CRD exposure in v3.6.24) | [v3.6.24 notes](https://doc.traefik.io/traefik/v3.6/migrate/v3/#v3624) |

### Out of scope (tracked as follow-up)

- `providers.kubernetesCRD.crossProviderNamespaces` hardening (v3.6.17)
- `entryPoints.web.http.underscoreHeadersStrategy` (v3.6.22)
- `entryPoints.web.http.encodedCharacters.*` explicit hardening (v3.6.4 / v3.6.7)


[NOOS-1698]: https://noosenergy.atlassian.net/browse/NOOS-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ